### PR TITLE
Add ChronoSnap Cloudflare prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Node
+node_modules/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[codz]

--- a/chronosnap/README.md
+++ b/chronosnap/README.md
@@ -1,0 +1,32 @@
+# ChronoSnap
+
+Time-travel selfie booth built for the Nano Banana hackathon.
+
+## Development
+
+This project is designed for Cloudflare Pages + Functions.
+
+### Environment Variables
+- `GEMINI_API_KEY` – Gemini API key.
+- `ELEVEN_API_KEY` – ElevenLabs API key (optional for voice narration).
+
+### Local Testing
+```
+# Run from project root
+npx wrangler pages dev public
+```
+
+### Testing
+Install Playwright and other dependencies before executing the test suite:
+```
+npm install
+npm test
+```
+
+### Deploying
+1. Push this folder to a Git repository.
+2. Create a Cloudflare Pages project pointing at this directory.
+3. Add the environment variables above in the Pages settings.
+
+### Usage
+Open the site, upload a selfie, select one or more scenarios, and click **Generate**. The worker searches Unsplash for a public background photo for each scenario, then returns edited images using Gemini along with optional audio narrations.

--- a/chronosnap/functions/api/generate.js
+++ b/chronosnap/functions/api/generate.js
@@ -1,0 +1,55 @@
+import { GoogleGenerativeAI } from '@google/generative-ai';
+import fetch from 'cross-fetch';
+
+export const onRequestPost = async ({ request, env }) => {
+  const { image, scenarios } = await request.json();
+  const genAI = new GoogleGenerativeAI(env.GEMINI_API_KEY);
+  const model = genAI.getGenerativeModel({ model: 'gemini-2.5-flash-image-edit' });
+
+  const baseImage = Buffer.from(Uint8Array.from(image)).toString('base64');
+  const outputs = [];
+
+  for (const scene of scenarios) {
+    // attempt to fetch a public reference image
+    let reference;
+    try {
+      const bgRes = await fetch(`https://source.unsplash.com/featured/?${encodeURIComponent(scene)}`);
+      if (bgRes.ok) {
+        const bgArrayBuffer = await bgRes.arrayBuffer();
+        reference = Buffer.from(bgArrayBuffer).toString('base64');
+      }
+    } catch (e) {
+      // ignore network failures
+    }
+
+    // Image generation
+    const parts = [{ inlineData: { data: baseImage, mimeType: 'image/png' } }];
+    if (reference) {
+      parts.push({ inlineData: { data: reference, mimeType: 'image/jpeg' } });
+    }
+    parts.push({ text: `Place the person in ${scene}. Use the additional image as background if provided.` });
+
+    const result = await model.generateContent(parts);
+    const imageData = result.response.candidates[0].content.parts[0].inlineData.data;
+
+    let audio;
+    if (env.ELEVEN_API_KEY) {
+      const narration = `You are now in ${scene}.`;
+      const ttsRes = await fetch('https://api.elevenlabs.io/v1/text-to-speech/adam', {
+        method: 'POST',
+        headers: {
+          'xi-api-key': env.ELEVEN_API_KEY,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ text: narration })
+      });
+      audio = Buffer.from(await ttsRes.arrayBuffer()).toString('base64');
+    }
+
+    outputs.push({ image: imageData, audio, reference });
+  }
+
+  return new Response(JSON.stringify({ outputs }), {
+    headers: { 'Content-Type': 'application/json' }
+  });
+};

--- a/chronosnap/package.json
+++ b/chronosnap/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "chronosnap",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "@google/generative-ai": "^0.4.1",
+    "cross-fetch": "^3.1.8",
+    "wrangler": "^3.0.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.45.0"
+  }
+}

--- a/chronosnap/public/app.js
+++ b/chronosnap/public/app.js
@@ -1,0 +1,37 @@
+async function generate() {
+  const fileInput = document.getElementById('photo');
+  const select = document.getElementById('scenarios');
+  const results = document.getElementById('results');
+  results.innerHTML = '';
+  if (!fileInput.files[0]) return alert('Upload a photo first');
+
+  const arrayBuffer = await fileInput.files[0].arrayBuffer();
+  const scenarios = Array.from(select.selectedOptions).map(o => o.value);
+
+  const response = await fetch('/api/generate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ image: Array.from(new Uint8Array(arrayBuffer)), scenarios })
+  });
+
+  const data = await response.json();
+  data.outputs.forEach(({ image, audio, reference }) => {
+    if (reference) {
+      const refEl = document.createElement('img');
+      refEl.src = `data:image/jpeg;base64,${reference}`;
+      refEl.alt = 'reference background';
+      results.appendChild(refEl);
+    }
+    const imageEl = document.createElement('img');
+    imageEl.src = `data:image/png;base64,${image}`;
+    results.appendChild(imageEl);
+    if (audio) {
+      const audioEl = document.createElement('audio');
+      audioEl.controls = true;
+      audioEl.src = `data:audio/mpeg;base64,${audio}`;
+      results.appendChild(audioEl);
+    }
+  });
+}
+
+document.getElementById('generate').addEventListener('click', generate);

--- a/chronosnap/public/index.html
+++ b/chronosnap/public/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ChronoSnap</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <main>
+    <h1>ChronoSnap – Time-Travel Selfie Booth</h1>
+    <p>Upload a selfie and watch yourself travel across eras.</p>
+    <p>Background photos for each scenario are fetched from Unsplash.</p>
+    <input type="file" id="photo" accept="image/*" />
+    <select id="scenarios" multiple>
+      <option value="Ancient Egypt pyramid">Ancient Egypt</option>
+      <option value="Renaissance art studio">Renaissance</option>
+      <option value="futuristic Mars colony">Future Mars</option>
+    </select>
+    <button id="generate">Generate</button>
+    <section id="results"></section>
+  </main>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/chronosnap/public/styles.css
+++ b/chronosnap/public/styles.css
@@ -1,0 +1,3 @@
+body { font-family: Arial, sans-serif; margin: 2rem; }
+main { max-width: 600px; margin: auto; }
+#results img { max-width: 100%; margin-top: 1rem; }

--- a/chronosnap/tests/ui.spec.js
+++ b/chronosnap/tests/ui.spec.js
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const localUrl = 'file://' + path.resolve(__dirname, '../public/index.html');
+
+test('index loads and shows expected elements', async ({ page }) => {
+  await page.goto(localUrl);
+  await expect(page.locator('h1')).toHaveText('ChronoSnap – Time-Travel Selfie Booth');
+  await expect(page.locator('#photo')).toBeVisible();
+  await expect(page.locator('#scenarios')).toBeVisible();
+  await expect(page.locator('#scenarios option')).toHaveCount(3);
+  await expect(page.locator('#generate')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- Integrate GEMINI_API_KEY env variable for Gemini model access
- Fetch public Unsplash photos for each scenario and return as references
- Show reference backgrounds on client and document new env variable
- Add Playwright-based smoke test for the ChronoSnap UI
- Document testing steps for installing dependencies before running tests

## Testing
- `npm test` *(fails: sh: 1: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be730ba0f08333a0bd5ed1999702b3